### PR TITLE
Updated readme, removed netrwhist

### DIFF
--- a/.vim/.netrwhist
+++ b/.vim/.netrwhist
@@ -1,8 +1,0 @@
-let g:netrw_dirhistmax  =10
-let g:netrw_dirhist_cnt =6
-let g:netrw_dirhist_1='/usr/local/google/home/beeps/goproj/src/github.com/google/cadvisor/client'
-let g:netrw_dirhist_2='/usr/local/google/home/beeps/goproj/src/github.com/google/cadvisor/container'
-let g:netrw_dirhist_3='/usr/local/google/home/beeps/goproj/src/github.com/google/cadvisor'
-let g:netrw_dirhist_4='/usr/local/google/home/beeps/goproj/src/github.com/google/cadvisor/info'
-let g:netrw_dirhist_5='/usr/local/google/home/beeps/goproj/src/github.com/GoogleCloudPlatform/kubernetes/pkg/apiserver'
-let g:netrw_dirhist_6='/usr/local/google/home/beeps/goproj/src/github.com/prometheus/procfs'

--- a/README.md
+++ b/README.md
@@ -1,1 +1,10 @@
 # Dotfiles
+
+This is a fairly dumb mirror of my .vim directory. It will not work out
+of the box (godeps need installation, ycm needs building etc).
+
+# TODO:
+* Add an install script that installs pathogen and clones appropriate
+  bundles.
+* Document installation procedure for go packages.
+* Remove unwanted bundles.


### PR DESCRIPTION
This removes netrwhist which is a temporary file created to manage the history of edits to .vim. 
